### PR TITLE
:memo: Adding upgrade policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,11 @@ After running the Docker Compose file, you can access the FusionAuth admin site 
 
 Add testing.
 
+
+## Upgrade Policy
+
+This library is built automatically to keep track of the FusionAuth API, and may also receive updates with bug fixes, security patches, tests, code samples, or documentation changes.
+
+These releases may also update dependencies, language engines, and operating systems, as we\'ll follow the deprecation and sunsetting policies of the underlying technologies that it uses.
+
+This means that after a dependency (e.g. language, framework, or operating system) is deprecated by its maintainer, this library will also be deprecated by us, and will eventually be updated to use a newer version.


### PR DESCRIPTION
Adding the "Upgrade Policy" section as [described here](https://github.com/FusionAuth/fusionauth-site/pull/2916).